### PR TITLE
Solved numerical imprecision in timestamping

### DIFF
--- a/audiostream2py/data.py
+++ b/audiostream2py/data.py
@@ -188,7 +188,7 @@ class AudioSegment:
             )
         frame_idx = frame_idx % self.frame_count
         bt = self.start_date + frame_idx * self.frame_period
-        tt = bt + self.frame_period
+        tt = self.start_date + (frame_idx + 1) * self.frame_period
         return bt, tt
 
     def _get_slice(self, s: slice) -> 'AudioSegment':


### PR DESCRIPTION
We sometimes had a continuity problem when doing:
```
audio_segment_1 = audio_sequence[t0:t1]
audio_segment_2 = audio_sequence[t1:t2]
```
because `audio_segment_1.end_date` was not equal to `audio_segment_2.start_date`.  

This was due to a numerical imprecision solved in this pull-request.